### PR TITLE
refactor: remove dead getImageTabs and extract shared isTwitterMediaUrl

### DIFF
--- a/src/__tests__/modules.test.ts
+++ b/src/__tests__/modules.test.ts
@@ -9,7 +9,7 @@ import {
   getFileName,
   sleep,
 } from '../popup/imageUrl'
-import { getImageTabs, getImageSources } from '../popup/chromeApi'
+import { getImageSources } from '../popup/chromeApi'
 
 describe('isImageFormat', () => {
   it.each([
@@ -184,39 +184,6 @@ describe('sleep', () => {
     vi.advanceTimersByTime(1000)
     await expect(promise).resolves.toBeUndefined()
     vi.useRealTimers()
-  })
-})
-
-describe('getImageTabs', () => {
-  const queryMock = chrome.tabs.query as unknown as Mock
-
-  beforeEach(() => {
-    queryMock.mockReset()
-  })
-
-  it('filters tabs to only image tabs', async () => {
-    const mockTabs = [
-      { id: 1, url: 'https://example.com/photo.png' },
-      { id: 2, url: 'https://example.com/page.html' },
-      { id: 3, url: 'https://pbs.twimg.com/media/abc?format=jpg&name=orig' },
-      { id: 4, url: undefined },
-    ] as chrome.tabs.Tab[]
-
-    queryMock.mockResolvedValue(mockTabs)
-
-    const result = await getImageTabs()
-    expect(result).toHaveLength(2)
-    expect(result[0].id).toBe(1)
-    expect(result[1].id).toBe(3)
-  })
-
-  it('returns empty array when no image tabs exist', async () => {
-    queryMock.mockResolvedValue([
-      { id: 1, url: 'https://example.com/' },
-    ] as chrome.tabs.Tab[])
-
-    const result = await getImageTabs()
-    expect(result).toHaveLength(0)
   })
 })
 

--- a/src/popup/chromeApi.ts
+++ b/src/popup/chromeApi.ts
@@ -23,13 +23,6 @@ export const getSyncData = async <T = Record<string, unknown>>(keys: string[]): 
   }
 }
 
-export const getImageTabs = async (): Promise<chrome.tabs.Tab[]> => {
-  const tabs = await chrome.tabs.query({ currentWindow: true })
-  const imageTabs = tabs.filter((tab) => tab.url !== undefined && isImageURL(tab.url))
-  console.log(`${imageTabs.length} image tabs found.`)
-  return imageTabs
-}
-
 export type ImageSource = {
   tab: chrome.tabs.Tab
   imageUrl: string

--- a/src/popup/imageUrl.ts
+++ b/src/popup/imageUrl.ts
@@ -9,10 +9,12 @@ export const isImageFormat = (url: string): boolean => {
   return IMAGE_EXTENSIONS.some((ext) => u.pathname.toLowerCase().endsWith(`.${ext}`))
 }
 
+const isTwitterMediaUrl = (u: URL): boolean =>
+  u.host === "pbs.twimg.com" && u.pathname.startsWith("/media/")
+
 export const isTwitterImage = (url: string): boolean => {
   const u = new URL(url)
-  const isTwitterMedia = u.host === "pbs.twimg.com" && u.pathname.startsWith("/media/")
-  if (!isTwitterMedia) return false
+  if (!isTwitterMediaUrl(u)) return false
   return IMAGE_EXTENSIONS.includes(u.searchParams.get("format") ?? "")
 }
 
@@ -47,7 +49,7 @@ export const getXPhotoIndex = (url: string): number => {
 
 export const upgradeTwitterImageUrl = (url: string): string => {
   const u = new URL(url)
-  if (u.host === "pbs.twimg.com" && u.pathname.startsWith("/media/")) {
+  if (isTwitterMediaUrl(u)) {
     u.searchParams.set("name", "orig")
   }
   return u.toString()


### PR DESCRIPTION
Remove getImageTabs (superseded by getImageSources, no production callers) and extract isTwitterMediaUrl predicate to eliminate duplicated host+path check between isTwitterImage and upgradeTwitterImageUrl.