### PR TITLE
ダウンロード対象の画像をチェックボックスで除外できるようにする

### DIFF
--- a/e2e/tests/select-images.spec.ts
+++ b/e2e/tests/select-images.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from "../fixtures";
+
+test("excludes images from the download via row checkboxes", async ({
+  context,
+  imageServer,
+  extensionId,
+}) => {
+  const page1 = await context.newPage();
+  await page1.goto(`http://127.0.0.1:${imageServer.port}/test.png`);
+  const page2 = await context.newPage();
+  await page2.goto(`http://127.0.0.1:${imageServer.port}/test.jpg`);
+
+  const popup = await context.newPage();
+  await popup.goto(`chrome-extension://${extensionId}/src/popup/index.html`);
+
+  await expect(popup.getByText("2 image tabs found.")).toBeVisible();
+
+  const selectAll = popup.getByRole("checkbox", { name: "Select all" });
+  const pngCheckbox = popup.getByRole("checkbox", {
+    name: `Toggle http://127.0.0.1:${imageServer.port}/test.png`,
+    exact: true,
+  });
+  const jpgCheckbox = popup.getByRole("checkbox", {
+    name: `Toggle http://127.0.0.1:${imageServer.port}/test.jpg`,
+    exact: true,
+  });
+  const downloadBtn = popup.getByRole("button", { name: "Download" });
+
+  // Every found image is selected by default.
+  await expect(selectAll).toHaveAttribute("aria-checked", "true");
+  await expect(pngCheckbox).toBeChecked();
+  await expect(jpgCheckbox).toBeChecked();
+  await expect(popup.getByText("2 / 2 selected")).toBeVisible();
+  await expect(downloadBtn).toBeEnabled();
+
+  // Excluding one image lowers the count and makes "select all" indeterminate.
+  // Chakra's checkbox overlay intercepts pointer events, so force the click.
+  await pngCheckbox.uncheck({ force: true });
+  await expect(pngCheckbox).not.toBeChecked();
+  await expect(jpgCheckbox).toBeChecked();
+  await expect(popup.getByText("1 / 2 selected")).toBeVisible();
+  await expect(selectAll).toHaveAttribute("aria-checked", "mixed");
+  await expect(downloadBtn).toBeEnabled();
+
+  // With nothing selected there is nothing to download.
+  await jpgCheckbox.uncheck({ force: true });
+  await expect(popup.getByText("0 / 2 selected")).toBeVisible();
+  await expect(selectAll).toHaveAttribute("aria-checked", "false");
+  await expect(downloadBtn).toBeDisabled();
+
+  // "Select all" re-includes every image.
+  await selectAll.check({ force: true });
+  await expect(pngCheckbox).toBeChecked();
+  await expect(jpgCheckbox).toBeChecked();
+  await expect(popup.getByText("2 / 2 selected")).toBeVisible();
+  await expect(downloadBtn).toBeEnabled();
+});

--- a/src/__tests__/ImageTabList.test.tsx
+++ b/src/__tests__/ImageTabList.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { ChakraProvider } from '@chakra-ui/react'
 import { ImageTabList } from '../popup/components/ImageTabList'
 import type { ImageSource } from '../popup/chromeApi'
@@ -12,10 +12,30 @@ const makeSource = (id: number, imageUrl: string, tabUrl?: string): ImageSource 
   imageUrl,
 })
 
+const allSelected = (sources: ImageSource[]) =>
+  new Set(sources.map((s) => s.tab.id).filter((id): id is number => id !== undefined))
+
+type Overrides = {
+  selectedIds?: Set<number>
+  onToggle?: (id: number) => void
+  onToggleAll?: () => void
+}
+
+const renderList = (sources: ImageSource[], overrides: Overrides = {}) =>
+  renderWithChakra(
+    <ImageTabList
+      sources={sources}
+      selectedIds={overrides.selectedIds ?? allSelected(sources)}
+      onToggle={overrides.onToggle ?? (() => {})}
+      onToggleAll={overrides.onToggleAll ?? (() => {})}
+    />,
+  )
+
 describe('ImageTabList', () => {
   it('renders nothing when sources is empty', () => {
-    renderWithChakra(<ImageTabList sources={[]} />)
+    renderList([])
     expect(screen.queryAllByRole('link')).toHaveLength(0)
+    expect(screen.queryAllByRole('checkbox')).toHaveLength(0)
   })
 
   it('renders a list of image sources', () => {
@@ -24,7 +44,7 @@ describe('ImageTabList', () => {
       makeSource(2, 'https://example.com/photo2.jpg'),
     ]
 
-    renderWithChakra(<ImageTabList sources={sources} />)
+    renderList(sources)
 
     const links = screen.getAllByRole('link')
     expect(links).toHaveLength(2)
@@ -37,7 +57,7 @@ describe('ImageTabList', () => {
       makeSource(1, 'https://pbs.twimg.com/media/abc?format=jpg&name=orig', 'https://x.com/user/status/123/photo/1'),
     ]
 
-    renderWithChakra(<ImageTabList sources={sources} />)
+    renderList(sources)
 
     const img = screen.getByRole('presentation')
     expect(img).toHaveAttribute('src', 'https://pbs.twimg.com/media/abc?format=jpg&name=orig')
@@ -48,7 +68,7 @@ describe('ImageTabList', () => {
       makeSource(1, 'https://pbs.twimg.com/media/abc?format=jpg&name=orig', 'https://x.com/user/status/123/photo/1'),
     ]
 
-    renderWithChakra(<ImageTabList sources={sources} />)
+    renderList(sources)
 
     const link = screen.getByRole('link')
     expect(link).toHaveAttribute('href', 'https://x.com/user/status/123/photo/1')
@@ -57,10 +77,101 @@ describe('ImageTabList', () => {
   it('opens links in a new tab', () => {
     const sources = [makeSource(1, 'https://example.com/photo.png')]
 
-    renderWithChakra(<ImageTabList sources={sources} />)
+    renderList(sources)
 
     const link = screen.getByRole('link')
     expect(link).toHaveAttribute('target', '_blank')
     expect(link).toHaveAttribute('rel', 'noreferrer')
+  })
+
+  it('renders a checkbox per source plus a select-all checkbox', () => {
+    const sources = [
+      makeSource(1, 'https://example.com/photo1.png'),
+      makeSource(2, 'https://example.com/photo2.jpg'),
+    ]
+
+    renderList(sources)
+
+    // 2 rows + 1 "select all" header checkbox
+    expect(screen.getAllByRole('checkbox')).toHaveLength(3)
+    expect(screen.getByRole('checkbox', { name: 'Select all' })).toBeInTheDocument()
+  })
+
+  it('checks rows present in selectedIds and unchecks the rest', () => {
+    const sources = [
+      makeSource(1, 'https://example.com/photo1.png'),
+      makeSource(2, 'https://example.com/photo2.jpg'),
+    ]
+
+    renderList(sources, { selectedIds: new Set([1]) })
+
+    const [, row1, row2] = screen.getAllByRole('checkbox')
+    expect(row1).toBeChecked()
+    expect(row2).not.toBeChecked()
+  })
+
+  it('calls onToggle with the tab id when a row checkbox is clicked', () => {
+    const onToggle = vi.fn()
+    const sources = [
+      makeSource(10, 'https://example.com/photo1.png'),
+      makeSource(20, 'https://example.com/photo2.jpg'),
+    ]
+
+    renderList(sources, { onToggle })
+
+    const [, row1, row2] = screen.getAllByRole('checkbox')
+    fireEvent.click(row1)
+    fireEvent.click(row2)
+
+    expect(onToggle).toHaveBeenCalledTimes(2)
+    expect(onToggle).toHaveBeenNthCalledWith(1, 10)
+    expect(onToggle).toHaveBeenNthCalledWith(2, 20)
+  })
+
+  it('calls onToggleAll when the select-all checkbox is clicked', () => {
+    const onToggleAll = vi.fn()
+    const sources = [makeSource(1, 'https://example.com/photo1.png')]
+
+    renderList(sources, { onToggleAll })
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Select all' }))
+
+    expect(onToggleAll).toHaveBeenCalledTimes(1)
+  })
+
+  it('reflects all / none / partial selection in the select-all checkbox', () => {
+    const sources = [
+      makeSource(1, 'https://example.com/photo1.png'),
+      makeSource(2, 'https://example.com/photo2.jpg'),
+    ]
+
+    const { rerender } = renderList(sources, { selectedIds: new Set([1, 2]) })
+    expect(screen.getByRole('checkbox', { name: 'Select all' })).toBeChecked()
+    expect(screen.getByRole('checkbox', { name: 'Select all' })).not.toBePartiallyChecked()
+
+    const withProps = (selectedIds: Set<number>) => (
+      <ChakraProvider>
+        <ImageTabList sources={sources} selectedIds={selectedIds} onToggle={() => {}} onToggleAll={() => {}} />
+      </ChakraProvider>
+    )
+
+    rerender(withProps(new Set([1])))
+    expect(screen.getByRole('checkbox', { name: 'Select all' })).toBePartiallyChecked()
+
+    rerender(withProps(new Set()))
+    const selectAll = screen.getByRole('checkbox', { name: 'Select all' })
+    expect(selectAll).not.toBeChecked()
+    expect(selectAll).not.toBePartiallyChecked()
+  })
+
+  it('shows the selected count', () => {
+    const sources = [
+      makeSource(1, 'https://example.com/photo1.png'),
+      makeSource(2, 'https://example.com/photo2.jpg'),
+    ]
+
+    renderList(sources, { selectedIds: new Set([1]) })
+
+    expect(screen.getByText('1 / 2 selected')).toBeInTheDocument()
   })
 })

--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -50,10 +50,47 @@ const downloadImages = async (
 const App = () => {
   const [imageSources, setImageSources] = useState<ImageSource[] | null>(null);
   const [isClicked, setIsClicked] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
 
   useEffect(() => {
-    getImageSources().then(setImageSources);
+    getImageSources().then((sources) => {
+      setImageSources(sources);
+      // Select every found image by default; the user can uncheck the ones to skip.
+      setSelectedIds(
+        new Set(
+          sources
+            .map((source) => source.tab.id)
+            .filter((id): id is number => id !== undefined),
+        ),
+      );
+    });
   }, []);
+
+  const toggleSelected = (id: number) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const toggleAll = () => {
+    const ids = (imageSources ?? [])
+      .map((source) => source.tab.id)
+      .filter((id): id is number => id !== undefined);
+    setSelectedIds((prev) => {
+      const allSelected = ids.length > 0 && ids.every((id) => prev.has(id));
+      return allSelected ? new Set() : new Set(ids);
+    });
+  };
+
+  const selectedSources = (imageSources ?? []).filter(
+    (source) => source.tab.id !== undefined && selectedIds.has(source.tab.id),
+  );
 
   return (
     <ChakraProvider>
@@ -62,7 +99,12 @@ const App = () => {
           {imageSources !== null ? `${imageSources.length} image tabs found.` : ""}
         </Text>
 
-        <ImageTabList sources={imageSources ?? []} />
+        <ImageTabList
+          sources={imageSources ?? []}
+          selectedIds={selectedIds}
+          onToggle={toggleSelected}
+          onToggleAll={toggleAll}
+        />
 
         <Button
           style={{ marginTop: "10px", display: "block", margin: "10px auto 0" }}
@@ -71,9 +113,9 @@ const App = () => {
           aria-label="Download"
           size="lg"
           leftIcon={<DownloadIcon />}
-          onClick={() => downloadImages(imageSources ?? [], setIsClicked)}
+          onClick={() => downloadImages(selectedSources, setIsClicked)}
           isLoading={isClicked}
-          isDisabled={imageSources === null || imageSources.length === 0}
+          isDisabled={selectedSources.length === 0}
         >
           Download Images
         </Button>

--- a/src/popup/components/ImageTabList.tsx
+++ b/src/popup/components/ImageTabList.tsx
@@ -1,63 +1,114 @@
-import { Box } from "@chakra-ui/react";
+import { Box, Checkbox, Flex, Text } from "@chakra-ui/react";
 import type { ImageSource } from "@/popup/chromeApi";
 
 type Props = {
   sources: ImageSource[];
+  selectedIds: Set<number>;
+  onToggle: (id: number) => void;
+  onToggleAll: () => void;
 };
 
-export const ImageTabList = ({ sources }: Props) => {
+export const ImageTabList = ({
+  sources,
+  selectedIds,
+  onToggle,
+  onToggleAll,
+}: Props) => {
   if (sources.length === 0) return null;
+
+  const selectableIds = sources
+    .map((source) => source.tab.id)
+    .filter((id): id is number => id !== undefined);
+  const selectedCount = selectableIds.filter((id) => selectedIds.has(id)).length;
+  const allSelected =
+    selectableIds.length > 0 && selectedCount === selectableIds.length;
+  const someSelected = selectedCount > 0;
 
   return (
     <Box
       mt={2}
-      maxHeight="240px"
-      overflowY="auto"
       borderWidth="1px"
       borderColor="gray.200"
       borderRadius="md"
+      overflow="hidden"
     >
-      {sources.map((source) => (
-        <Box
-          key={source.tab.id}
-          display="flex"
-          alignItems="center"
-          gap={2}
-          px={2}
-          py={1}
-          _notLast={{ borderBottomWidth: "1px", borderColor: "gray.100" }}
+      <Flex
+        align="center"
+        justify="space-between"
+        px={2}
+        py={1}
+        borderBottomWidth="1px"
+        borderColor="gray.200"
+        bg="gray.50"
+      >
+        <Checkbox
+          size="sm"
+          isChecked={allSelected}
+          isIndeterminate={someSelected && !allSelected}
+          onChange={onToggleAll}
         >
-          <img
-            src={source.imageUrl}
-            alt=""
-            style={{
-              width: "48px",
-              height: "48px",
-              objectFit: "cover",
-              flexShrink: 0,
-              borderRadius: "4px",
-              background: "#eee",
-            }}
-          />
-          <a
-            href={source.tab.url}
-            target="_blank"
-            rel="noreferrer"
-            title={source.imageUrl}
-            style={{
-              fontSize: "12px",
-              color: "#3182ce",
-              overflow: "hidden",
-              whiteSpace: "nowrap",
-              textOverflow: "ellipsis",
-              display: "block",
-              minWidth: 0,
-            }}
-          >
-            {source.imageUrl}
-          </a>
-        </Box>
-      ))}
+          <Text fontSize="xs">Select all</Text>
+        </Checkbox>
+        <Text fontSize="xs" color="gray.500">
+          {selectedCount} / {selectableIds.length} selected
+        </Text>
+      </Flex>
+
+      <Box maxHeight="240px" overflowY="auto">
+        {sources.map((source) => {
+          const id = source.tab.id;
+          const isChecked = id !== undefined && selectedIds.has(id);
+          return (
+            <Box
+              key={id}
+              display="flex"
+              alignItems="center"
+              gap={2}
+              px={2}
+              py={1}
+              _notLast={{ borderBottomWidth: "1px", borderColor: "gray.100" }}
+            >
+              <Checkbox
+                size="sm"
+                isChecked={isChecked}
+                isDisabled={id === undefined}
+                onChange={() => id !== undefined && onToggle(id)}
+                aria-label={`Toggle ${source.imageUrl}`}
+                flexShrink={0}
+              />
+              <img
+                src={source.imageUrl}
+                alt=""
+                style={{
+                  width: "48px",
+                  height: "48px",
+                  objectFit: "cover",
+                  flexShrink: 0,
+                  borderRadius: "4px",
+                  background: "#eee",
+                }}
+              />
+              <a
+                href={source.tab.url}
+                target="_blank"
+                rel="noreferrer"
+                title={source.imageUrl}
+                style={{
+                  fontSize: "12px",
+                  color: "#3182ce",
+                  overflow: "hidden",
+                  whiteSpace: "nowrap",
+                  textOverflow: "ellipsis",
+                  display: "block",
+                  minWidth: 0,
+                }}
+              >
+                {source.imageUrl}
+              </a>
+            </Box>
+          );
+        })}
+      </Box>
     </Box>
   );
 };


### PR DESCRIPTION
## 概要

ダウンロード対象の画像一覧 (`ImageTabList`) に各行のチェックボックスと「Select all」ヘッダーを追加し、ダウンロードしたくない画像をリストから外せるようにしました。

## 変更内容

- **`ImageTabList`** を制御コンポーネント化
  - 各行の左端にチェックボックスを追加（チェック = ダウンロード対象）
  - ヘッダーに「Select all」チェックボックス（全選択 / 全解除、一部選択時は indeterminate 表示）と選択数 `N / M selected` を表示
- **`App`** が選択状態 (`selectedIds`) を管理
  - デフォルトは「すべて選択」なので、操作しなければ従来どおり全件ダウンロードされ既存の挙動を維持
  - チェックの入った画像 (`selectedSources`) だけをダウンロード処理に渡す
  - 選択が 0 件のときは Download ボタンを無効化

## UI イメージ

```
┌────────────────────────────────────┐
│ ☑ Select all            2 / 2 selected │
├────────────────────────────────────┤
│ ☑  [img]  https://.../photo1.png       │
│ ☐  [img]  https://.../photo2.jpg       │  ← 外したいものはチェックを外す
└────────────────────────────────────┘
```

## テスト

- **ユニットテスト** (`src/__tests__/ImageTabList.test.tsx`): 新しい props への追従に加え、チェックボックスの描画・選択状態の反映・`onToggle` / `onToggleAll` の発火・選択数表示を検証する 6 件を追加
- **E2E テスト** (`e2e/tests/select-images.spec.ts`): 画像タブを 2 つ開き、1 件除外 → 全解除 → 全選択 と操作してカウント表示・`Select all` の状態・Download ボタンの活性状態が連動することを検証
- `npm test`（60 件）/ `npm run type-check` / `npm run build` がパス

> [!NOTE]
> E2E のブラウザ取得が本実行環境ではブロックされているためローカルでの実行はできていません（`npx playwright test --list` でのパースと検出は確認済み）。実際の実行は CI に委ねています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C9ArfxSa5eX6Ror2mKHeze

---
_Generated by [Claude Code](https://claude.ai/code/session_01C9ArfxSa5eX6Ror2mKHeze)_