### PR TITLE
Add support for yande.re (Moebooru) booru post pages

### DIFF
--- a/e2e/assets/yandere-post-page.html
+++ b/e2e/assets/yandere-post-page.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html>
+<head><title>/bra danimaru | post #1253771 | yande.re</title></head>
+<body>
+  <!-- Mirrors the DOM of a yande.re (Moebooru) post page, e.g.
+       https://yande.re/post/show/1253771
+       The displayed sample image is rendered in <img id="image">. The src here
+       is a relative local path so the e2e test can verify the extracted URL is
+       actually downloadable. The id/structure mirror the real page. -->
+  <div id="post-view">
+    <div id="content">
+      <div id="right-col">
+        <span class="thumb"><img src="test.png" alt="related thumbnail"></span>
+      </div>
+      <div id="image-container" data-id="1253771" data-file-url="https://files.yande.re/image/6cbcc2f97d722a85ec6db3af7a7c8093/yande.re%201253771.jpg">
+        <img alt="bra danimaru lingerie" class="image" id="image" src="test.jpg">
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/e2e/tests/booru-post-page.spec.ts
+++ b/e2e/tests/booru-post-page.spec.ts
@@ -17,6 +17,7 @@ const extractionScript = `
 for (const site of [
   { name: "Danbooru", page: "danbooru-post-page.html" },
   { name: "Gelbooru", page: "gelbooru-post-page.html" },
+  { name: "yande.re", page: "yandere-post-page.html" },
 ]) {
   test.describe(site.name, () => {
     test("extraction script returns the displayed #image src", async ({

--- a/e2e/tests/real-download.spec.ts
+++ b/e2e/tests/real-download.spec.ts
@@ -102,3 +102,95 @@ test.describe("Gelbooru real download", () => {
     expect(downloadInfo!.totalBytes).toBeGreaterThan(1000);
   });
 });
+
+test.describe("yande.re real download", () => {
+  // Real example from the feature request: opening this post page, the
+  // displayed <img id="image"> points at the files.yande.re sample image.
+  const POST_URL = "https://yande.re/post/show/1253771";
+
+  test("image URL extraction works", async ({ context }) => {
+    const page = await context.newPage();
+    await page.goto(POST_URL, {
+      waitUntil: "domcontentloaded",
+      timeout: 30_000,
+    });
+
+    const src: string | null = await page.evaluate(extractImageSrc);
+
+    expect(src).not.toBeNull();
+    expect(src).toMatch(/^https:\/\/files\.yande\.re\//);
+  });
+
+  test("popup detects yande.re tab and downloads actual image", async ({
+    context,
+    extensionId,
+  }) => {
+    // Open the yande.re post page
+    const postPage = await context.newPage();
+    await postPage.goto(POST_URL, {
+      waitUntil: "domcontentloaded",
+      timeout: 30_000,
+    });
+
+    // Open the extension popup — this triggers getImageSources(), which detects
+    // the yande.re post tab and extracts the displayed image.
+    const popup = await context.newPage();
+    await popup.goto(
+      `chrome-extension://${extensionId}/src/popup/index.html`
+    );
+
+    // Wait for the popup to detect the yande.re image tab.
+    await expect(popup.getByText("1 image tabs found.")).toBeVisible({
+      timeout: 30_000,
+    });
+
+    // Listen for console errors during download
+    const consoleErrors: string[] = [];
+    popup.on("console", (msg) => {
+      if (msg.type() === "error") consoleErrors.push(msg.text());
+    });
+
+    // Click download
+    const downloadBtn = popup.getByRole("button", { name: "Download" });
+    await expect(downloadBtn).toBeEnabled();
+    await downloadBtn.click();
+
+    // Loading state should appear then clear
+    await expect(downloadBtn).toHaveAttribute("data-loading", {
+      timeout: 5_000,
+    });
+    await expect(downloadBtn).not.toHaveAttribute("data-loading", {
+      timeout: 15_000,
+    });
+
+    // No download-related errors
+    const downloadErrors = consoleErrors.filter((e) =>
+      e.toLowerCase().includes("download")
+    );
+    expect(downloadErrors).toHaveLength(0);
+
+    // Verify the last completed download is an actual image — not an HTML
+    // hotlink-protection page disguised as a JPEG. This is what proves
+    // files.yande.re serves the image with a direct download (no Referer
+    // workaround needed).
+    const downloadInfo = await popup.evaluate(async () => {
+      const items = await new Promise<chrome.downloads.DownloadItem[]>(
+        (resolve) =>
+          chrome.downloads.search(
+            { orderBy: ["-startTime"], limit: 1 },
+            resolve
+          )
+      );
+      const item = items[0];
+      return item
+        ? { state: item.state, mime: item.mime, totalBytes: item.totalBytes }
+        : null;
+    });
+
+    console.log("Download info:", downloadInfo);
+    expect(downloadInfo).not.toBeNull();
+    expect(downloadInfo!.state).toBe("complete");
+    expect(downloadInfo!.mime).toContain("image");
+    expect(downloadInfo!.totalBytes).toBeGreaterThan(1000);
+  });
+});

--- a/manifest.config.ts
+++ b/manifest.config.ts
@@ -23,6 +23,8 @@ export default defineManifest({
     "https://*.donmai.us/*",
     "https://gelbooru.com/*",
     "https://*.gelbooru.com/*",
+    "https://yande.re/*",
+    "https://files.yande.re/*",
   ],
   background: {
     service_worker: "src/background.ts",

--- a/src/__tests__/modules.test.ts
+++ b/src/__tests__/modules.test.ts
@@ -10,6 +10,7 @@ import {
   sleep,
   isDanbooruPostPage,
   isGelbooruPostPage,
+  isYanderePostPage,
   isBooruPostPage,
 } from '../popup/imageUrl'
 import { getImageSources } from '../popup/chromeApi'
@@ -153,12 +154,37 @@ describe('isGelbooruPostPage', () => {
   })
 })
 
+describe('isYanderePostPage', () => {
+  it.each([
+    'https://yande.re/post/show/1253771',
+    'https://yande.re/post/show/1',
+    // yande.re sometimes appends a tag slug after the id
+    'https://yande.re/post/show/1253771/bra',
+  ])('returns true for yande.re post page: %s', (url) => {
+    expect(isYanderePostPage(url)).toBe(true)
+  })
+
+  it.each([
+    'https://yande.re/post/show',
+    'https://yande.re/post/show/abc',
+    'https://yande.re/post',
+    'https://yande.re/',
+    'https://yande.re/pool/show/123',
+    'https://yande.re.evil.com/post/show/123',
+    'https://files.yande.re/post/show/123',
+    'https://example.com/post/show/123',
+  ])('returns false for non post page: %s', (url) => {
+    expect(isYanderePostPage(url)).toBe(false)
+  })
+})
+
 describe('isBooruPostPage', () => {
-  it('returns true for both Danbooru and Gelbooru post pages', () => {
+  it('returns true for Danbooru, Gelbooru and yande.re post pages', () => {
     expect(isBooruPostPage('https://danbooru.donmai.us/posts/11655837')).toBe(true)
     expect(
       isBooruPostPage('https://gelbooru.com/index.php?page=post&s=view&id=14357815'),
     ).toBe(true)
+    expect(isBooruPostPage('https://yande.re/post/show/1253771')).toBe(true)
   })
 
   it('returns false for unrelated pages', () => {
@@ -400,6 +426,27 @@ describe('getImageSources', () => {
     expect(result[0].tab.url).toBe(
       'https://gelbooru.com/index.php?page=post&s=view&id=14357815',
     )
+  })
+
+  it('extracts the sample image URL from a yande.re post page', async () => {
+    // Real example: visiting https://yande.re/post/show/1253771, the displayed
+    // <img id="image"> points at the sample image that should be downloaded.
+    queryMock.mockResolvedValue([
+      { id: 1, url: 'https://yande.re/post/show/1253771' },
+    ] as chrome.tabs.Tab[])
+    scriptMock.mockResolvedValue([
+      {
+        result:
+          'https://files.yande.re/sample/6cbcc2f97d722a85ec6db3af7a7c8093/yande.re%201253771%20sample%20bra%20danimaru%20lingerie%20open_shirt%20see_through%20seifuku.jpg',
+      },
+    ])
+
+    const result = await getImageSources()
+    expect(result).toHaveLength(1)
+    expect(result[0].imageUrl).toBe(
+      'https://files.yande.re/sample/6cbcc2f97d722a85ec6db3af7a7c8093/yande.re%201253771%20sample%20bra%20danimaru%20lingerie%20open_shirt%20see_through%20seifuku.jpg',
+    )
+    expect(result[0].tab.url).toBe('https://yande.re/post/show/1253771')
   })
 
   it('skips Booru post page tabs when no image is found', async () => {

--- a/src/popup/imageUrl.ts
+++ b/src/popup/imageUrl.ts
@@ -79,8 +79,18 @@ export const isGelbooruPostPage = (url: string): boolean => {
   }
 }
 
+// Moebooru engine (yande.re): /post/show/<id> (optionally followed by a tag slug)
+export const isYanderePostPage = (url: string): boolean => {
+  try {
+    const u = new URL(url)
+    return u.host === "yande.re" && /^\/post\/show\/\d+(?:\/[^/]*)?$/.test(u.pathname)
+  } catch {
+    return false
+  }
+}
+
 export const isBooruPostPage = (url: string): boolean =>
-  isDanbooruPostPage(url) || isGelbooruPostPage(url)
+  isDanbooruPostPage(url) || isGelbooruPostPage(url) || isYanderePostPage(url)
 
 export const upgradeTwitterImageUrl = (url: string): string => {
   const u = new URL(url)


### PR DESCRIPTION
## Summary
This PR adds support for extracting images from yande.re post pages, extending the existing booru image extraction functionality to include Moebooru-based sites.

## Key Changes
- **New URL detection function**: Added `isYanderePostPage()` to identify yande.re post pages with the pattern `/post/show/<id>` (optionally followed by a tag slug)
- **Updated booru detection**: Modified `isBooruPostPage()` to include yande.re alongside Danbooru and Gelbooru
- **Manifest permissions**: Added host permissions for `yande.re` and `files.yande.re` to allow content script execution and image access
- **Image extraction**: Added test coverage for extracting sample image URLs from yande.re post pages
- **E2E testing**: Added yandere-post-page.html fixture and integrated yande.re into the booru post page e2e test suite

## Implementation Details
- The `isYanderePostPage()` function validates the hostname is exactly "yande.re" and uses a regex pattern to match the post URL structure, preventing false positives from subdomains or similar domains
- The extraction targets the `<img id="image">` element on yande.re post pages, which displays the sample image
- Test coverage includes valid post URLs with and without tag slugs, as well as negative cases for invalid URLs and subdomain variations

https://claude.ai/code/session_01DH845vab2Pxoq7ezvLkgXp