### PR TITLE
feat: add Pixiv artwork page support

### DIFF
--- a/e2e/tests/pixiv-artwork-page.spec.ts
+++ b/e2e/tests/pixiv-artwork-page.spec.ts
@@ -13,7 +13,8 @@ const extractionScript = `
     const imgs = document.querySelectorAll('img[src*="i.pximg.net"]');
     const urls = [];
     for (const img of imgs) {
-      if (img.src.includes('/img-master/') || img.src.includes('/img-original/')) {
+      const path = new URL(img.src).pathname;
+      if (path.startsWith('/img-master/') || path.startsWith('/img-original/')) {
         urls.push(img.src);
       }
     }

--- a/e2e/tests/pixiv-artwork-page.spec.ts
+++ b/e2e/tests/pixiv-artwork-page.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect } from "../fixtures";
+
+// These tests verify that images from real Pixiv artwork pages are correctly
+// extracted.  They require network access and hit live pixiv.net servers.
+// Run only this file: npx playwright test e2e/tests/pixiv-artwork-page.spec.ts
+
+const extractionScript = `
+  (() => {
+    const originalLinks = document.querySelectorAll('a[href*="i.pximg.net/img-original/"]');
+    if (originalLinks.length > 0) {
+      return Array.from(originalLinks).map(a => a.href);
+    }
+    const imgs = document.querySelectorAll('img[src*="i.pximg.net"]');
+    const urls = [];
+    for (const img of imgs) {
+      if (img.src.includes('/img-master/') || img.src.includes('/img-original/')) {
+        urls.push(img.src);
+      }
+    }
+    return urls;
+  })()
+`;
+
+test.describe("Pixiv single-image artwork", () => {
+  const ARTWORK_URL = "https://www.pixiv.net/artworks/123720628";
+
+  test("extracts the artwork image URL", async ({ context }) => {
+    const page = await context.newPage();
+    await page.goto(ARTWORK_URL, {
+      waitUntil: "networkidle",
+      timeout: 30_000,
+    });
+
+    const urls: string[] = await page.evaluate(extractionScript);
+
+    expect(urls.length).toBeGreaterThanOrEqual(1);
+    expect(urls[0]).toContain(
+      "i.pximg.net/img-master/img/2024/10/27/13/02/51/123720628_p0_master1200.jpg",
+    );
+  });
+});
+
+test.describe("Pixiv multi-image artwork", () => {
+  const ARTWORK_URL = "https://www.pixiv.net/artworks/134386572";
+
+  test("extracts all page image URLs", async ({ context }) => {
+    const page = await context.newPage();
+    await page.goto(ARTWORK_URL, {
+      waitUntil: "networkidle",
+      timeout: 30_000,
+    });
+
+    const urls: string[] = await page.evaluate(extractionScript);
+
+    expect(urls.length).toBeGreaterThanOrEqual(2);
+    expect(urls[0]).toContain(
+      "i.pximg.net/img-master/img/2025/08/27/16/55/34/134386572_p0_master1200.jpg",
+    );
+    expect(urls[1]).toContain(
+      "i.pximg.net/img-master/img/2025/08/27/16/55/34/134386572_p1_master1200.jpg",
+    );
+  });
+});

--- a/e2e/tests/pixiv-artwork-page.spec.ts
+++ b/e2e/tests/pixiv-artwork-page.spec.ts
@@ -5,11 +5,17 @@ import { test, expect } from "../fixtures";
 // Run only this file: npx playwright test e2e/tests/pixiv-artwork-page.spec.ts
 
 const extractionScript = `
-  (() => {
-    const originalLinks = document.querySelectorAll('a[href*="i.pximg.net/img-original/"]');
-    if (originalLinks.length > 0) {
-      return Array.from(originalLinks).map(a => a.href);
-    }
+  (async () => {
+    const match = location.pathname.match(/\\/artworks\\/(\\d+)/);
+    if (!match) return [];
+    const id = match[1];
+    try {
+      const res = await fetch('/ajax/illust/' + id + '/pages');
+      const data = await res.json();
+      if (!data.error && Array.isArray(data.body)) {
+        return data.body.map(p => p.urls.regular);
+      }
+    } catch {}
     const imgs = document.querySelectorAll('img[src*="i.pximg.net"]');
     const urls = [];
     for (const img of imgs) {

--- a/manifest.config.ts
+++ b/manifest.config.ts
@@ -25,6 +25,8 @@ export default defineManifest({
     "https://*.gelbooru.com/*",
     "https://yande.re/*",
     "https://files.yande.re/*",
+    "https://www.pixiv.net/*",
+    "https://*.pximg.net/*",
   ],
   background: {
     service_worker: "src/background.ts",

--- a/src/__tests__/modules.test.ts
+++ b/src/__tests__/modules.test.ts
@@ -303,7 +303,7 @@ describe('getFileName', () => {
   it('extracts filename from a Pixiv image URL', () => {
     expect(
       getFileName(
-        'https://i.pimg.net/img-master/img/2024/01/01/00/00/00/12345678_p0_master1200.jpg',
+        'https://i.pximg.net/img-master/img/2024/01/01/00/00/00/12345678_p0_master1200.jpg',
       ),
     ).toBe('12345678_p0_master1200.jpg')
   })
@@ -311,7 +311,7 @@ describe('getFileName', () => {
   it('extracts filename from a Pixiv original image URL', () => {
     expect(
       getFileName(
-        'https://i.pimg.net/img-original/img/2024/01/01/00/00/00/12345678_p0.png',
+        'https://i.pximg.net/img-original/img/2024/01/01/00/00/00/12345678_p0.png',
       ),
     ).toBe('12345678_p0.png')
   })
@@ -515,24 +515,50 @@ describe('getImageSources', () => {
     ] as chrome.tabs.Tab[])
     scriptMock.mockResolvedValue([
       {
-        result:
-          'https://i.pimg.net/img-master/img/2024/01/01/00/00/00/12345678_p0_master1200.jpg',
+        result: [
+          'https://i.pximg.net/img-master/img/2024/01/01/00/00/00/12345678_p0_master1200.jpg',
+        ],
       },
     ])
 
     const result = await getImageSources()
     expect(result).toHaveLength(1)
     expect(result[0].imageUrl).toBe(
-      'https://i.pimg.net/img-master/img/2024/01/01/00/00/00/12345678_p0_master1200.jpg',
+      'https://i.pximg.net/img-master/img/2024/01/01/00/00/00/12345678_p0_master1200.jpg',
     )
     expect(result[0].tab.url).toBe('https://www.pixiv.net/artworks/12345678')
+  })
+
+  it('extracts multiple image URLs from a multi-page Pixiv artwork', async () => {
+    queryMock.mockResolvedValue([
+      { id: 1, url: 'https://www.pixiv.net/artworks/12345678' },
+    ] as chrome.tabs.Tab[])
+    scriptMock.mockResolvedValue([
+      {
+        result: [
+          'https://i.pximg.net/img-master/img/2024/01/01/00/00/00/12345678_p0_master1200.jpg',
+          'https://i.pximg.net/img-master/img/2024/01/01/00/00/00/12345678_p1_master1200.jpg',
+        ],
+      },
+    ])
+
+    const result = await getImageSources()
+    expect(result).toHaveLength(2)
+    expect(result[0].imageUrl).toBe(
+      'https://i.pximg.net/img-master/img/2024/01/01/00/00/00/12345678_p0_master1200.jpg',
+    )
+    expect(result[1].imageUrl).toBe(
+      'https://i.pximg.net/img-master/img/2024/01/01/00/00/00/12345678_p1_master1200.jpg',
+    )
+    expect(result[0].tab.url).toBe('https://www.pixiv.net/artworks/12345678')
+    expect(result[1].tab.url).toBe('https://www.pixiv.net/artworks/12345678')
   })
 
   it('skips Pixiv artwork page tabs when no image is found', async () => {
     queryMock.mockResolvedValue([
       { id: 1, url: 'https://www.pixiv.net/artworks/12345678' },
     ] as chrome.tabs.Tab[])
-    scriptMock.mockResolvedValue([{ result: null }])
+    scriptMock.mockResolvedValue([{ result: [] }])
 
     const result = await getImageSources()
     expect(result).toHaveLength(0)

--- a/src/__tests__/modules.test.ts
+++ b/src/__tests__/modules.test.ts
@@ -12,6 +12,7 @@ import {
   isGelbooruPostPage,
   isYanderePostPage,
   isBooruPostPage,
+  isPixivArtworkPage,
 } from '../popup/imageUrl'
 import { getImageSources } from '../popup/chromeApi'
 
@@ -192,6 +193,29 @@ describe('isBooruPostPage', () => {
   })
 })
 
+describe('isPixivArtworkPage', () => {
+  it.each([
+    'https://www.pixiv.net/artworks/12345678',
+    'https://www.pixiv.net/en/artworks/12345678',
+    'https://www.pixiv.net/ja/artworks/99999999',
+    'https://pixiv.net/artworks/12345678',
+  ])('returns true for Pixiv artwork page: %s', (url) => {
+    expect(isPixivArtworkPage(url)).toBe(true)
+  })
+
+  it.each([
+    'https://www.pixiv.net/artworks',
+    'https://www.pixiv.net/artworks/',
+    'https://www.pixiv.net/artworks/abc',
+    'https://www.pixiv.net/users/12345',
+    'https://www.pixiv.net/',
+    'https://example.com/artworks/12345678',
+    'https://www.pixiv.net/en/artworks/12345678/edit',
+  ])('returns false for non artwork page: %s', (url) => {
+    expect(isPixivArtworkPage(url)).toBe(false)
+  })
+})
+
 describe('upgradeTwitterImageUrl', () => {
   it('sets name=orig for Twitter media URLs', () => {
     expect(
@@ -274,6 +298,22 @@ describe('getFileName', () => {
         'https://img4.gelbooru.com//samples/15/65/sample_156599b000c99a786d987fa30ab25d27.jpg',
       ),
     ).toBe('sample_156599b000c99a786d987fa30ab25d27.jpg')
+  })
+
+  it('extracts filename from a Pixiv image URL', () => {
+    expect(
+      getFileName(
+        'https://i.pimg.net/img-master/img/2024/01/01/00/00/00/12345678_p0_master1200.jpg',
+      ),
+    ).toBe('12345678_p0_master1200.jpg')
+  })
+
+  it('extracts filename from a Pixiv original image URL', () => {
+    expect(
+      getFileName(
+        'https://i.pimg.net/img-original/img/2024/01/01/00/00/00/12345678_p0.png',
+      ),
+    ).toBe('12345678_p0.png')
   })
 })
 
@@ -462,6 +502,45 @@ describe('getImageSources', () => {
   it('skips Booru post page tabs when script injection fails', async () => {
     queryMock.mockResolvedValue([
       { id: 1, url: 'https://gelbooru.com/index.php?page=post&s=view&id=14357815' },
+    ] as chrome.tabs.Tab[])
+    scriptMock.mockRejectedValue(new Error('injection failed'))
+
+    const result = await getImageSources()
+    expect(result).toHaveLength(0)
+  })
+
+  it('extracts image URL from a Pixiv artwork page', async () => {
+    queryMock.mockResolvedValue([
+      { id: 1, url: 'https://www.pixiv.net/artworks/12345678' },
+    ] as chrome.tabs.Tab[])
+    scriptMock.mockResolvedValue([
+      {
+        result:
+          'https://i.pimg.net/img-master/img/2024/01/01/00/00/00/12345678_p0_master1200.jpg',
+      },
+    ])
+
+    const result = await getImageSources()
+    expect(result).toHaveLength(1)
+    expect(result[0].imageUrl).toBe(
+      'https://i.pimg.net/img-master/img/2024/01/01/00/00/00/12345678_p0_master1200.jpg',
+    )
+    expect(result[0].tab.url).toBe('https://www.pixiv.net/artworks/12345678')
+  })
+
+  it('skips Pixiv artwork page tabs when no image is found', async () => {
+    queryMock.mockResolvedValue([
+      { id: 1, url: 'https://www.pixiv.net/artworks/12345678' },
+    ] as chrome.tabs.Tab[])
+    scriptMock.mockResolvedValue([{ result: null }])
+
+    const result = await getImageSources()
+    expect(result).toHaveLength(0)
+  })
+
+  it('skips Pixiv artwork page tabs when script injection fails', async () => {
+    queryMock.mockResolvedValue([
+      { id: 1, url: 'https://www.pixiv.net/artworks/12345678' },
     ] as chrome.tabs.Tab[])
     scriptMock.mockRejectedValue(new Error('injection failed'))
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -13,7 +13,7 @@ chrome.runtime.onInstalled.addListener(() => {
 
   // Gelbooru's CDN rejects requests without a Referer from gelbooru.com
   // (hotlink protection). Add the header so chrome.downloads.download works.
-  // Pixiv's CDN (i.pimg.net) similarly requires a Referer from pixiv.net.
+  // Pixiv's CDN (i.pximg.net) similarly requires a Referer from pixiv.net.
   chrome.declarativeNetRequest.updateDynamicRules({
     removeRuleIds: [1, 2],
     addRules: [
@@ -52,7 +52,7 @@ chrome.runtime.onInstalled.addListener(() => {
           ],
         },
         condition: {
-          requestDomains: ["pimg.net"],
+          requestDomains: ["pximg.net"],
           resourceTypes: [
             chrome.declarativeNetRequest.ResourceType.IMAGE,
             chrome.declarativeNetRequest.ResourceType.OTHER,

--- a/src/background.ts
+++ b/src/background.ts
@@ -13,8 +13,9 @@ chrome.runtime.onInstalled.addListener(() => {
 
   // Gelbooru's CDN rejects requests without a Referer from gelbooru.com
   // (hotlink protection). Add the header so chrome.downloads.download works.
+  // Pixiv's CDN (i.pimg.net) similarly requires a Referer from pixiv.net.
   chrome.declarativeNetRequest.updateDynamicRules({
-    removeRuleIds: [1],
+    removeRuleIds: [1, 2],
     addRules: [
       {
         id: 1,
@@ -31,6 +32,27 @@ chrome.runtime.onInstalled.addListener(() => {
         },
         condition: {
           requestDomains: ["gelbooru.com"],
+          resourceTypes: [
+            chrome.declarativeNetRequest.ResourceType.IMAGE,
+            chrome.declarativeNetRequest.ResourceType.OTHER,
+          ],
+        },
+      },
+      {
+        id: 2,
+        priority: 1,
+        action: {
+          type: chrome.declarativeNetRequest.RuleActionType.MODIFY_HEADERS,
+          requestHeaders: [
+            {
+              header: "Referer",
+              operation: chrome.declarativeNetRequest.HeaderOperation.SET,
+              value: "https://www.pixiv.net/",
+            },
+          ],
+        },
+        condition: {
+          requestDomains: ["pimg.net"],
           resourceTypes: [
             chrome.declarativeNetRequest.ResourceType.IMAGE,
             chrome.declarativeNetRequest.ResourceType.OTHER,

--- a/src/popup/chromeApi.ts
+++ b/src/popup/chromeApi.ts
@@ -61,31 +61,32 @@ export const extractBooruImageUrl = async (tabId: number): Promise<string | null
   return results?.[0]?.result ?? null
 }
 
-// Pixiv artwork pages render images from i.pimg.net. Extract the main
-// artwork image URL from the DOM.
-export const extractPixivImageUrl = async (tabId: number): Promise<string | null> => {
+// Pixiv artwork pages render images from i.pximg.net. Extract all artwork
+// image URLs from the DOM (a multi-page work shows all pages on one page).
+export const extractPixivImageUrls = async (tabId: number): Promise<string[]> => {
   const results = await chrome.scripting.executeScript({
     target: { tabId },
     func: () => {
       // Prefer links to original-quality images
-      const originalLinks = document.querySelectorAll<HTMLAnchorElement>('a[href*="i.pimg.net/img-original/"]')
+      const originalLinks = document.querySelectorAll<HTMLAnchorElement>('a[href*="i.pximg.net/img-original/"]')
       if (originalLinks.length > 0) {
-        return originalLinks[0].href
+        return Array.from(originalLinks).map((a) => a.href)
       }
       // Fall back to displayed master/regular images
-      const imgs = document.querySelectorAll<HTMLImageElement>('img[src*="i.pimg.net"]')
+      const imgs = document.querySelectorAll<HTMLImageElement>('img[src*="i.pximg.net"]')
+      const urls: string[] = []
       for (const img of imgs) {
         if (img.src.includes("/img-master/") || img.src.includes("/img-original/")) {
-          return img.src
+          urls.push(img.src)
         }
       }
-      return null
+      return urls
     },
   })
-  return results?.[0]?.result ?? null
+  return results?.[0]?.result ?? []
 }
 
-// Some CDNs (Gelbooru's img*.gelbooru.com, Pixiv's i.pimg.net) reject requests
+// Some CDNs (Gelbooru's img*.gelbooru.com, Pixiv's i.pximg.net) reject requests
 // without a proper Referer header.  chrome.downloads.download() sends no
 // Referer, so direct downloads may silently fail.
 //
@@ -167,7 +168,7 @@ export const getImageSources = async (): Promise<ImageSource[]> => {
       (tab): tab is chrome.tabs.Tab & { url: string; id: number } =>
         tab.url !== undefined && tab.id !== undefined,
     )
-    .map(async (tab): Promise<ImageSource | null> => {
+    .map(async (tab): Promise<ImageSource | ImageSource[] | null> => {
       if (isImageURL(tab.url)) {
         return { tab, imageUrl: tab.url }
       }
@@ -201,13 +202,14 @@ export const getImageSources = async (): Promise<ImageSource[]> => {
       }
       if (isPixivArtworkPage(tab.url)) {
         try {
-          const imageUrl = await extractPixivImageUrl(tab.id)
-          if (imageUrl) {
-            const downloadUrl = await fetchImageAsDataUrl(tab.id, imageUrl)
-            if (downloadUrl) {
-              return { tab, imageUrl, downloadUrl }
+          const imageUrls = await extractPixivImageUrls(tab.id)
+          if (imageUrls.length > 0) {
+            const sources: ImageSource[] = []
+            for (const imageUrl of imageUrls) {
+              const downloadUrl = await fetchImageAsDataUrl(tab.id, imageUrl)
+              sources.push(downloadUrl ? { tab, imageUrl, downloadUrl } : { tab, imageUrl })
             }
-            return { tab, imageUrl }
+            return sources
           }
         } catch (e) {
           console.error(`Failed to extract image from tab ${tab.id}:`, e)
@@ -217,7 +219,7 @@ export const getImageSources = async (): Promise<ImageSource[]> => {
     })
 
   const results = await Promise.all(sourcePromises)
-  const sources = results.filter((s): s is ImageSource => s !== null)
+  const sources = results.flat().filter((s): s is ImageSource => s !== null)
   console.log(`${sources.length} image sources found.`)
   return sources
 }

--- a/src/popup/chromeApi.ts
+++ b/src/popup/chromeApi.ts
@@ -61,19 +61,25 @@ export const extractBooruImageUrl = async (tabId: number): Promise<string | null
   return results?.[0]?.result ?? null
 }
 
-// Pixiv artwork pages render images from i.pximg.net. Extract all artwork
-// image URLs from the DOM (a multi-page work shows all pages on one page).
+// Pixiv artwork pages render images from i.pximg.net.  Multi-page works
+// lazy-load images, so DOM extraction alone misses pages below the fold.
+// Use Pixiv's AJAX API to reliably get all page URLs, with DOM fallback.
 export const extractPixivImageUrls = async (tabId: number): Promise<string[]> => {
   const results = await chrome.scripting.executeScript({
     target: { tabId },
-    func: () => {
-      // Prefer links to original-quality images
-      const originalLinks = document.querySelectorAll<HTMLAnchorElement>('a[href*="i.pximg.net/img-original/"]')
-      if (originalLinks.length > 0) {
-        return Array.from(originalLinks).map((a) => a.href)
-      }
-      // Fall back to displayed master/regular images.
-      // Exclude thumbnails whose path contains a resize prefix like /c/250x250_80_a2/
+    world: "MAIN",
+    func: async () => {
+      const match = location.pathname.match(/\/artworks\/(\d+)/)
+      if (!match) return []
+      const id = match[1]
+      try {
+        const res = await fetch(`/ajax/illust/${id}/pages`)
+        const data = await res.json()
+        if (!data.error && Array.isArray(data.body)) {
+          return data.body.map((p: { urls: { regular: string } }) => p.urls.regular)
+        }
+      } catch { /* fall through to DOM extraction */ }
+      // Fallback: extract from visible <img> elements
       const imgs = document.querySelectorAll<HTMLImageElement>('img[src*="i.pximg.net"]')
       const urls: string[] = []
       for (const img of imgs) {

--- a/src/popup/chromeApi.ts
+++ b/src/popup/chromeApi.ts
@@ -72,11 +72,13 @@ export const extractPixivImageUrls = async (tabId: number): Promise<string[]> =>
       if (originalLinks.length > 0) {
         return Array.from(originalLinks).map((a) => a.href)
       }
-      // Fall back to displayed master/regular images
+      // Fall back to displayed master/regular images.
+      // Exclude thumbnails whose path contains a resize prefix like /c/250x250_80_a2/
       const imgs = document.querySelectorAll<HTMLImageElement>('img[src*="i.pximg.net"]')
       const urls: string[] = []
       for (const img of imgs) {
-        if (img.src.includes("/img-master/") || img.src.includes("/img-original/")) {
+        const path = new URL(img.src).pathname
+        if (path.startsWith("/img-master/") || path.startsWith("/img-original/")) {
           urls.push(img.src)
         }
       }

--- a/src/popup/chromeApi.ts
+++ b/src/popup/chromeApi.ts
@@ -5,6 +5,7 @@ import {
   upgradeTwitterImageUrl,
   isBooruPostPage,
   isGelbooruPostPage,
+  isPixivArtworkPage,
 } from "@/popup/imageUrl"
 
 export const setSyncData = (key: string, value: unknown) => {
@@ -60,16 +61,40 @@ export const extractBooruImageUrl = async (tabId: number): Promise<string | null
   return results?.[0]?.result ?? null
 }
 
-// Gelbooru's CDN (img*.gelbooru.com) rejects requests without a Referer from
-// *.gelbooru.com.  chrome.downloads.download() sends no Referer, so direct
-// downloads silently receive an HTML page instead of the image.
+// Pixiv artwork pages render images from i.pimg.net. Extract the main
+// artwork image URL from the DOM.
+export const extractPixivImageUrl = async (tabId: number): Promise<string | null> => {
+  const results = await chrome.scripting.executeScript({
+    target: { tabId },
+    func: () => {
+      // Prefer links to original-quality images
+      const originalLinks = document.querySelectorAll<HTMLAnchorElement>('a[href*="i.pimg.net/img-original/"]')
+      if (originalLinks.length > 0) {
+        return originalLinks[0].href
+      }
+      // Fall back to displayed master/regular images
+      const imgs = document.querySelectorAll<HTMLImageElement>('img[src*="i.pimg.net"]')
+      for (const img of imgs) {
+        if (img.src.includes("/img-master/") || img.src.includes("/img-original/")) {
+          return img.src
+        }
+      }
+      return null
+    },
+  })
+  return results?.[0]?.result ?? null
+}
+
+// Some CDNs (Gelbooru's img*.gelbooru.com, Pixiv's i.pimg.net) reject requests
+// without a proper Referer header.  chrome.downloads.download() sends no
+// Referer, so direct downloads may silently fail.
 //
-// Workaround: create a hidden iframe on the Gelbooru page that loads the image
-// URL.  The iframe request carries the correct Referer (from gelbooru.com), so
-// the CDN serves the real image.  Once the iframe has loaded, we inject a
-// script into it that re-fetches the image (same-origin at img*.gelbooru.com)
-// and returns a data-URL that chrome.downloads.download() can use.
-export const fetchGelbooruImageAsDataUrl = async (
+// Workaround: create a hidden iframe on the source page that loads the image
+// URL.  The iframe request carries the correct Referer (from the parent page),
+// so the CDN serves the real image.  Once the iframe has loaded, we inject a
+// script into it that re-fetches the image (same-origin) and returns a
+// data-URL that chrome.downloads.download() can use.
+export const fetchImageAsDataUrl = async (
   tabId: number,
   imageUrl: string,
 ): Promise<string | null> => {
@@ -163,10 +188,24 @@ export const getImageSources = async (): Promise<ImageSource[]> => {
           const imageUrl = await extractBooruImageUrl(tab.id)
           if (imageUrl) {
             if (isGelbooruPostPage(tab.url)) {
-              const downloadUrl = await fetchGelbooruImageAsDataUrl(tab.id, imageUrl)
+              const downloadUrl = await fetchImageAsDataUrl(tab.id, imageUrl)
               if (downloadUrl) {
                 return { tab, imageUrl, downloadUrl }
               }
+            }
+            return { tab, imageUrl }
+          }
+        } catch (e) {
+          console.error(`Failed to extract image from tab ${tab.id}:`, e)
+        }
+      }
+      if (isPixivArtworkPage(tab.url)) {
+        try {
+          const imageUrl = await extractPixivImageUrl(tab.id)
+          if (imageUrl) {
+            const downloadUrl = await fetchImageAsDataUrl(tab.id, imageUrl)
+            if (downloadUrl) {
+              return { tab, imageUrl, downloadUrl }
             }
             return { tab, imageUrl }
           }

--- a/src/popup/imageUrl.ts
+++ b/src/popup/imageUrl.ts
@@ -92,6 +92,19 @@ export const isYanderePostPage = (url: string): boolean => {
 export const isBooruPostPage = (url: string): boolean =>
   isDanbooruPostPage(url) || isGelbooruPostPage(url) || isYanderePostPage(url)
 
+// Pixiv artwork pages: /artworks/<id> (with optional language prefix like /en/)
+export const isPixivArtworkPage = (url: string): boolean => {
+  try {
+    const u = new URL(url)
+    return (
+      (u.host === "www.pixiv.net" || u.host === "pixiv.net") &&
+      /^(\/[a-z]{2})?\/artworks\/\d+$/.test(u.pathname)
+    )
+  } catch {
+    return false
+  }
+}
+
 export const upgradeTwitterImageUrl = (url: string): string => {
   const u = new URL(url)
   if (isTwitterMediaUrl(u)) {


### PR DESCRIPTION
## Summary

- Pixivのアートワークページ (`/artworks/<id>`) から画像を検出・ダウンロードできるようにした
- 複数画像のアートワーク（漫画形式）にも対応し、1つのタブから全ページを抽出
- Pixiv CDN (`i.pximg.net`) のホットリンク保護に対応（Refererヘッダー設定 + iframe/data-URL方式）
- Gelbooru用の `fetchGelbooruImageAsDataUrl` を汎用的な `fetchImageAsDataUrl` にリネームし、Pixivでも再利用

## Changes

- `src/popup/imageUrl.ts`: `isPixivArtworkPage()` を追加（言語プレフィックス付きURLにも対応）
- `src/popup/chromeApi.ts`: `extractPixivImageUrls()` で全画像を抽出、`getImageSources()` で複数ImageSource生成
- `src/background.ts`: `i.pximg.net` へのRefererヘッダー追加ルール
- `manifest.config.ts`: `www.pixiv.net`, `*.pximg.net` をhost_permissionsに追加
- `e2e/tests/pixiv-artwork-page.spec.ts`: 実URLでのE2Eテスト（単一画像・複数画像）

## Test plan

- [x] ユニットテスト: `isPixivArtworkPage` のURL検出
- [x] ユニットテスト: `getImageSources` のPixiv単一画像・複数画像抽出
- [x] ユニットテスト: Pixiv画像URLからのファイル名抽出
- [ ] E2Eテスト: 実Pixiv URLへのアクセスが必要（ローカル実行）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K7e9SApZScALwEKHRpMvqC

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7e9SApZScALwEKHRpMvqC)_