### PR TITLE
fix: close tab only after download completes successfully

### DIFF
--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -1,8 +1,8 @@
 import { useState, useEffect } from "react";
 import { Button, Text, ChakraProvider, Divider, Box } from "@chakra-ui/react";
 import { DownloadIcon } from "@chakra-ui/icons";
-import { getFileName, sleep } from "./imageUrl";
-import { getImageSources, downloadFile, getSyncData, type ImageSource } from "./chromeApi";
+import { getFileName } from "./imageUrl";
+import { getImageSources, downloadFile, waitForDownloadComplete, getSyncData, type ImageSource } from "./chromeApi";
 import { Settings } from "@/background";
 import { CloseTabAfterDownload } from "./components/CloseTabAfterDownload";
 import { DownloadDirSetting } from "./components/DownloadDirSetting";
@@ -31,9 +31,7 @@ const downloadImages = async (
         const downloadId = await downloadFile(source.downloadUrl ?? source.imageUrl, savePath);
         console.log(`File download started. Download ID: ${downloadId}`);
         if (doClose) {
-          // chrome.downloads.download resolves when the download starts, not completes.
-          // Wait briefly so the browser registers the download before the tab is closed.
-          await sleep(0.5);
+          await waitForDownloadComplete(downloadId);
           chrome.tabs.remove(tabId, () =>
             console.log(`Tab closed: ${source.tab.url}`),
           );

--- a/src/popup/chromeApi.ts
+++ b/src/popup/chromeApi.ts
@@ -240,3 +240,21 @@ export const downloadFile = (url: string, filename: string): Promise<number> => 
   })
   return downloading
 }
+
+export const waitForDownloadComplete = (downloadId: number): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    const listener = (delta: chrome.downloads.DownloadDelta) => {
+      if (delta.id !== downloadId) return
+      if (!delta.state) return
+
+      if (delta.state.current === "complete") {
+        chrome.downloads.onChanged.removeListener(listener)
+        resolve()
+      } else if (delta.state.current === "interrupted") {
+        chrome.downloads.onChanged.removeListener(listener)
+        reject(new Error(`Download interrupted: ${delta.id}`))
+      }
+    }
+    chrome.downloads.onChanged.addListener(listener)
+  })
+}


### PR DESCRIPTION
Replace sleep-based wait with chrome.downloads.onChanged listener so tabs are closed only on successful download, not on errors.