### PR TITLE
Internationalize UI strings in popup components

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -6,7 +6,18 @@
   "optionTabCloseDesc": {
     "message": "Close the image tabs after downloading"
   },
-  "optionDownloadDirDesc": {
-    "message": "The download location will follow your Chrome settings. If you want to save images in a subdirectory, enter it below."
+  "imageTabsFound": {
+    "message": "$count$ image tabs found.",
+    "placeholders": {
+      "count": {
+        "content": "$1"
+      }
+    }
+  },
+  "chromesDownloadLocation": {
+    "message": "Chrome's Download Location"
+  },
+  "subdirectoryOptional": {
+    "message": "Subdirectory (optional)"
   }
 }

--- a/public/_locales/ja/messages.json
+++ b/public/_locales/ja/messages.json
@@ -6,7 +6,18 @@
   "optionTabCloseDesc": {
     "message": "画像をダウンロード後にタブを閉じる"
   },
-  "optionDownloadDirDesc": {
-    "message": "ダウンロード場所はChromeの設定に従います。サブディレクトリに保存したい場合は以下に入力してください。"
+  "imageTabsFound": {
+    "message": "$count$個の画像のタブを検出しました",
+    "placeholders": {
+      "count": {
+        "content": "$1"
+      }
+    }
+  },
+  "chromesDownloadLocation": {
+    "message": "Chromeのダウンロードフォルダ"
+  },
+  "subdirectoryOptional": {
+    "message": "新規フォルダ名(任意)"
   }
 }

--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -94,7 +94,11 @@ const App = () => {
     <ChakraProvider>
       <div style={{ margin: "10px", width: "500px" }}>
         <Text fontSize="md">
-          {imageSources !== null ? `${imageSources.length} image tabs found.` : ""}
+          {imageSources !== null
+            ? (chrome.i18n === undefined
+              ? `${imageSources.length} image tabs found.`
+              : chrome.i18n.getMessage("imageTabsFound", [String(imageSources.length)]))
+            : ""}
         </Text>
 
         <ImageTabList

--- a/src/popup/components/DownloadDirSetting.tsx
+++ b/src/popup/components/DownloadDirSetting.tsx
@@ -35,14 +35,18 @@ export const DownloadDirSetting = () => {
   return (
     <InputGroup size="sm">
       <InputLeftAddon fontSize="xs">
-        Chrome's Download Location /
+        {chrome.i18n === undefined
+          ? "Chrome's Download Location"
+          : chrome.i18n.getMessage("chromesDownloadLocation")} /
       </InputLeftAddon>
       <Input
         type="text"
         pr="4rem"
         value={downloadDir}
         onChange={handleChange}
-        placeholder="Subdirectory (optional)"
+        placeholder={chrome.i18n === undefined
+          ? "Subdirectory (optional)"
+          : chrome.i18n.getMessage("subdirectoryOptional")}
         fontSize="sm"
       />
       <InputRightElement width="4.5rem">


### PR DESCRIPTION
## Summary
This PR adds internationalization (i18n) support to user-facing strings in the popup UI by replacing hardcoded English text with localized message keys from Chrome's i18n API.

## Key Changes
- **Localization files updated**: Added three new message keys to both English and Japanese locale files:
  - `imageTabsFound`: Displays the count of detected image tabs with placeholder support
  - `chromesDownloadLocation`: Label for Chrome's download location setting
  - `subdirectoryOptional`: Placeholder text for optional subdirectory input
  - Removed the old `optionDownloadDirDesc` key that combined multiple concepts

- **DownloadDirSetting.tsx**: Updated to use localized strings for the download directory input component:
  - "Chrome's Download Location" label now uses `chromesDownloadLocation` message key
  - "Subdirectory (optional)" placeholder now uses `subdirectoryOptional` message key
  - Added fallback to English text when `chrome.i18n` is undefined

- **App.tsx**: Updated the image tabs found message to use the new `imageTabsFound` message key with dynamic count parameter, replacing the hardcoded English string

## Implementation Details
- All UI string changes include fallback logic to handle cases where `chrome.i18n` is undefined
- The `imageTabsFound` message uses Chrome's placeholder syntax (`$count$` and `$1`) to support dynamic count values
- Japanese translations provided for all new message keys

https://claude.ai/code/session_01FSpTGm6JjfWzLk3hfNM6Ls