### PR TITLE
Add site parsing toggle setting to disable content extraction

### DIFF
--- a/e2e/tests/pixiv-artwork-page.spec.ts
+++ b/e2e/tests/pixiv-artwork-page.spec.ts
@@ -34,8 +34,8 @@ test.describe("Pixiv single-image artwork", () => {
   test("extracts the artwork image URL", async ({ context }) => {
     const page = await context.newPage();
     await page.goto(ARTWORK_URL, {
-      waitUntil: "networkidle",
-      timeout: 30_000,
+      waitUntil: "domcontentloaded",
+      timeout: 60_000,
     });
 
     const urls: string[] = await page.evaluate(extractionScript);
@@ -50,11 +50,12 @@ test.describe("Pixiv single-image artwork", () => {
 test.describe("Pixiv multi-image artwork", () => {
   const ARTWORK_URL = "https://www.pixiv.net/artworks/134386572";
 
-  test("extracts all page image URLs", async ({ context }) => {
+  test("extracts all page image URLs", async ({ context }, testInfo) => {
+    testInfo.setTimeout(60_000);
     const page = await context.newPage();
     await page.goto(ARTWORK_URL, {
-      waitUntil: "networkidle",
-      timeout: 30_000,
+      waitUntil: "domcontentloaded",
+      timeout: 60_000,
     });
 
     const urls: string[] = await page.evaluate(extractionScript);

--- a/e2e/tests/settings.spec.ts
+++ b/e2e/tests/settings.spec.ts
@@ -11,7 +11,7 @@ test("closes image tab after download when setting is enabled", async ({
     `chrome-extension://${extensionId}/src/popup/index.html`
   );
   // Wait for the checkbox state to load from storage (default is true/checked)
-  const checkbox = settingsPage.getByRole("checkbox");
+  const checkbox = settingsPage.getByRole("checkbox", { name: /Close the image tabs after/ });
   await expect(checkbox).toBeChecked({ timeout: 5_000 });
   await settingsPage.close();
 
@@ -54,7 +54,7 @@ test("keeps image tab open after download when setting is disabled", async ({
     `chrome-extension://${extensionId}/src/popup/index.html`
   );
   // Wait for storage-loaded state before interacting
-  const checkbox = settingsPage.getByRole("checkbox");
+  const checkbox = settingsPage.getByRole("checkbox", { name: /Close the image tabs after/ });
   await expect(checkbox).toBeChecked({ timeout: 5_000 });
   // Chakra UI checkbox overlay intercepts pointer events; use force click
   await checkbox.uncheck({ force: true });
@@ -126,7 +126,7 @@ test("persists settings across popup reopens", async ({
   );
 
   // Ensure checkbox is checked before toggling — earlier tests may have changed it
-  const checkbox = popup1.getByRole("checkbox");
+  const checkbox = popup1.getByRole("checkbox", { name: /Close the image tabs after/ });
   await expect(checkbox).toBeAttached({ timeout: 5_000 });
   if (!(await checkbox.isChecked())) {
     await checkbox.check({ force: true });
@@ -149,7 +149,7 @@ test("persists settings across popup reopens", async ({
     `chrome-extension://${extensionId}/src/popup/index.html`
   );
 
-  const checkbox2 = popup2.getByRole("checkbox");
+  const checkbox2 = popup2.getByRole("checkbox", { name: /Close the image tabs after/ });
   await expect(checkbox2).not.toBeChecked({ timeout: 5_000 });
   const dirInput2 = popup2.getByPlaceholder("Subdirectory (optional)");
   await expect(dirInput2).toHaveValue("my-folder");

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -3,6 +3,9 @@
     "message": "Download image in all opened tabs by one click",
     "description": "for the description field in manifest.json"
   },
+  "optionSiteParsingDesc": {
+    "message": "Extract images from supported sites (X, Pixiv, Booru, etc.)"
+  },
   "optionTabCloseDesc": {
     "message": "Close the image tabs after downloading"
   },

--- a/public/_locales/ja/messages.json
+++ b/public/_locales/ja/messages.json
@@ -3,6 +3,9 @@
     "message": "タブで開いた画像ファイルをまとめてダウンロードします",
     "description": "manifest.jsonのdescription用"
   },
+  "optionSiteParsingDesc": {
+    "message": "対応サイトから画像を取得する（X、Pixiv、Booruなど）"
+  },
   "optionTabCloseDesc": {
     "message": "画像をダウンロード後にタブを閉じる"
   },

--- a/src/__tests__/chromeApi.test.ts
+++ b/src/__tests__/chromeApi.test.ts
@@ -265,4 +265,18 @@ describe('getImageSources', () => {
       'https://pbs.twimg.com/media/xyz?format=png&name=orig',
     )
   })
+
+  it('skips site parsing when isSiteParsingEnabled is false', async () => {
+    queryMock.mockResolvedValue([
+      { id: 1, url: 'https://example.com/photo.png' },
+      { id: 2, url: 'https://x.com/user/status/123/photo/1' },
+      { id: 3, url: 'https://danbooru.donmai.us/posts/11655837' },
+      { id: 4, url: 'https://www.pixiv.net/artworks/12345678' },
+    ] as chrome.tabs.Tab[])
+
+    const result = await getImageSources({ isSiteParsingEnabled: false })
+    expect(result).toHaveLength(1)
+    expect(result[0].imageUrl).toBe('https://example.com/photo.png')
+    expect(scriptMock).not.toHaveBeenCalled()
+  })
 })

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,11 +1,13 @@
 export type Settings = {
   isCloseTabAfterDownload: boolean;
   downloadDir: string | null;
+  isSiteParsingEnabled: boolean;
 };
 
 const defaultSettings: Settings = {
   isCloseTabAfterDownload: true,
   downloadDir: null, // if null, use default download directory
+  isSiteParsingEnabled: true,
 };
 
 chrome.runtime.onInstalled.addListener(() => {

--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -6,6 +6,7 @@ import { getImageSources, downloadFile, waitForDownloadComplete, getSyncData, ty
 import { Settings } from "@/background";
 import { CloseTabAfterDownload } from "./components/CloseTabAfterDownload";
 import { DownloadDirSetting } from "./components/DownloadDirSetting";
+import { SiteParsingSetting } from "./components/SiteParsingSetting";
 import { ImageTabList } from "./components/ImageTabList";
 
 const downloadImages = async (
@@ -64,9 +65,14 @@ const App = () => {
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
 
   useEffect(() => {
-    getImageSources().then((sources) => {
+    const load = async () => {
+      let isSiteParsingEnabled = true;
+      try {
+        const settings = await getSyncData<Settings>(["isSiteParsingEnabled"]);
+        isSiteParsingEnabled = settings.isSiteParsingEnabled ?? true;
+      } catch { /* use default */ }
+      const sources = await getImageSources({ isSiteParsingEnabled });
       setImageSources(sources);
-      // Select every found image by default; the user can uncheck the ones to skip.
       setSelectedIds(
         new Set(
           sources
@@ -74,7 +80,8 @@ const App = () => {
             .filter((id): id is number => id !== undefined),
         ),
       );
-    });
+    };
+    load();
   }, []);
 
   const toggleSelected = (id: number) => {
@@ -147,7 +154,10 @@ const App = () => {
           >
             Settings
           </Text>
-          <CloseTabAfterDownload />
+          <SiteParsingSetting />
+          <Box mt={1}>
+            <CloseTabAfterDownload />
+          </Box>
           <Box mt={2}>
             <DownloadDirSetting />
           </Box>

--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -64,6 +64,18 @@ const App = () => {
   const [isClicked, setIsClicked] = useState(false);
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
 
+  const loadImages = async (isSiteParsingEnabled: boolean) => {
+    const sources = await getImageSources({ isSiteParsingEnabled });
+    setImageSources(sources);
+    setSelectedIds(
+      new Set(
+        sources
+          .map((source) => source.tab.id)
+          .filter((id): id is number => id !== undefined),
+      ),
+    );
+  };
+
   useEffect(() => {
     const load = async () => {
       let isSiteParsingEnabled = true;
@@ -71,15 +83,7 @@ const App = () => {
         const settings = await getSyncData<Settings>(["isSiteParsingEnabled"]);
         isSiteParsingEnabled = settings.isSiteParsingEnabled ?? true;
       } catch { /* use default */ }
-      const sources = await getImageSources({ isSiteParsingEnabled });
-      setImageSources(sources);
-      setSelectedIds(
-        new Set(
-          sources
-            .map((source) => source.tab.id)
-            .filter((id): id is number => id !== undefined),
-        ),
-      );
+      await loadImages(isSiteParsingEnabled);
     };
     load();
   }, []);
@@ -154,7 +158,7 @@ const App = () => {
           >
             Settings
           </Text>
-          <SiteParsingSetting />
+          <SiteParsingSetting onChange={(enabled) => loadImages(enabled)} />
           <Box mt={1}>
             <CloseTabAfterDownload />
           </Box>

--- a/src/popup/chromeApi.ts
+++ b/src/popup/chromeApi.ts
@@ -168,7 +168,10 @@ export const fetchImageAsDataUrl = async (
   return dataUrl
 }
 
-export const getImageSources = async (): Promise<ImageSource[]> => {
+export const getImageSources = async (
+  options: { isSiteParsingEnabled?: boolean } = {},
+): Promise<ImageSource[]> => {
+  const { isSiteParsingEnabled = true } = options
   const tabs = await chrome.tabs.query({ currentWindow: true })
 
   const sourcePromises = tabs
@@ -180,6 +183,7 @@ export const getImageSources = async (): Promise<ImageSource[]> => {
       if (isImageURL(tab.url)) {
         return { tab, imageUrl: tab.url }
       }
+      if (!isSiteParsingEnabled) return null
       if (isXPhotoPage(tab.url)) {
         try {
           const urls = await extractImageUrlsFromTab(tab.id)

--- a/src/popup/components/SiteParsingSetting.tsx
+++ b/src/popup/components/SiteParsingSetting.tsx
@@ -3,7 +3,11 @@ import { Checkbox, Text } from "@chakra-ui/react";
 import { setSyncData } from "@/popup/chromeApi";
 import { Settings } from "@/background";
 
-export const SiteParsingSetting = () => {
+export const SiteParsingSetting = ({
+  onChange,
+}: {
+  onChange?: (enabled: boolean) => void;
+}) => {
   const [isChecked, setIsChecked] = useState(true);
 
   useEffect(() => {
@@ -16,6 +20,7 @@ export const SiteParsingSetting = () => {
   const handleCheck = (event: React.ChangeEvent<HTMLInputElement>) => {
     setIsChecked(event.target.checked);
     setSyncData("isSiteParsingEnabled", event.target.checked);
+    onChange?.(event.target.checked);
   };
 
   return (

--- a/src/popup/components/SiteParsingSetting.tsx
+++ b/src/popup/components/SiteParsingSetting.tsx
@@ -1,0 +1,30 @@
+import { useState, useEffect } from "react";
+import { Checkbox, Text } from "@chakra-ui/react";
+import { setSyncData } from "@/popup/chromeApi";
+import { Settings } from "@/background";
+
+export const SiteParsingSetting = () => {
+  const [isChecked, setIsChecked] = useState(true);
+
+  useEffect(() => {
+    if (chrome.storage === undefined) return;
+    chrome.storage.sync.get(["isSiteParsingEnabled"], (result: Settings) => {
+      setIsChecked(result.isSiteParsingEnabled ?? true);
+    });
+  }, []);
+
+  const handleCheck = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setIsChecked(event.target.checked);
+    setSyncData("isSiteParsingEnabled", event.target.checked);
+  };
+
+  return (
+    <Checkbox size="sm" isChecked={isChecked} onChange={handleCheck}>
+      <Text fontSize="sm">
+        {chrome.i18n === undefined
+          ? "optionSiteParsingDesc"
+          : chrome.i18n.getMessage("optionSiteParsingDesc")}
+      </Text>
+    </Checkbox>
+  );
+};


### PR DESCRIPTION
## Summary
This PR adds a new user-configurable setting to enable/disable site-specific content parsing. Users can now toggle whether the extension should extract images from supported sites (X, Pixiv, Booru, etc.) or only download direct image URLs.

## Key Changes
- **New Setting Component**: Created `SiteParsingSetting` component that provides a checkbox to toggle site parsing functionality
- **Settings Management**: Added `isSiteParsingEnabled` to the `Settings` type with a default value of `true`
- **Image Source Loading**: Modified `getImageSources()` to accept an options parameter and respect the `isSiteParsingEnabled` setting, skipping site-specific parsing when disabled
- **UI Integration**: Integrated the new setting into the App component's settings section with proper spacing
- **Internationalization**: Added localized strings for the new setting in both English and Japanese
- **Test Coverage**: Added test case to verify that site parsing is properly skipped when the setting is disabled

## Implementation Details
- The setting is persisted using Chrome's sync storage API
- When `isSiteParsingEnabled` is `false`, the extension will only extract images from direct image URLs and skip all site-specific parsing logic (X, Pixiv, Danbooru, etc.)
- The default behavior remains unchanged (parsing enabled) to maintain backward compatibility
- The setting is loaded asynchronously on app initialization and passed to the image source extraction function

https://claude.ai/code/session_01R7hyUk2gGPrC9ayGMiKRVk