### PR TITLE
Add loading state to image tab detection

### DIFF
--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { Button, Text, ChakraProvider, Divider, Box } from "@chakra-ui/react";
+import { Button, Text, ChakraProvider, Divider, Box, Spinner, Flex } from "@chakra-ui/react";
 import { DownloadIcon } from "@chakra-ui/icons";
 import { getFileName } from "./imageUrl";
 import { getImageSources, downloadFile, waitForDownloadComplete, getSyncData, type ImageSource } from "./chromeApi";
@@ -62,18 +62,24 @@ const downloadImages = async (
 const App = () => {
   const [imageSources, setImageSources] = useState<ImageSource[] | null>(null);
   const [isClicked, setIsClicked] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
 
   const loadImages = async (isSiteParsingEnabled: boolean) => {
-    const sources = await getImageSources({ isSiteParsingEnabled });
-    setImageSources(sources);
-    setSelectedIds(
-      new Set(
-        sources
-          .map((source) => source.tab.id)
-          .filter((id): id is number => id !== undefined),
-      ),
-    );
+    setIsLoading(true);
+    try {
+      const sources = await getImageSources({ isSiteParsingEnabled });
+      setImageSources(sources);
+      setSelectedIds(
+        new Set(
+          sources
+            .map((source) => source.tab.id)
+            .filter((id): id is number => id !== undefined),
+        ),
+      );
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   useEffect(() => {
@@ -117,13 +123,20 @@ const App = () => {
   return (
     <ChakraProvider>
       <div style={{ margin: "10px", width: "500px" }}>
-        <Text fontSize="md">
-          {imageSources !== null
-            ? (chrome.i18n === undefined
-              ? `${imageSources.length} image tabs found.`
-              : chrome.i18n.getMessage("imageTabsFound", [String(imageSources.length)]))
-            : ""}
-        </Text>
+        {isLoading ? (
+          <Flex align="center" gap={2}>
+            <Spinner size="sm" color="blue.500" />
+            <Text fontSize="md">Checking tabs...</Text>
+          </Flex>
+        ) : (
+          <Text fontSize="md">
+            {imageSources !== null
+              ? (chrome.i18n === undefined
+                ? `${imageSources.length} image tabs found.`
+                : chrome.i18n.getMessage("imageTabsFound", [String(imageSources.length)]))
+              : ""}
+          </Text>
+        )}
 
         <ImageTabList
           sources={imageSources ?? []}
@@ -158,7 +171,7 @@ const App = () => {
           >
             Settings
           </Text>
-          <SiteParsingSetting onChange={(enabled) => loadImages(enabled)} />
+          <SiteParsingSetting onChange={(enabled) => loadImages(enabled)} isDisabled={isLoading} />
           <Box mt={1}>
             <CloseTabAfterDownload />
           </Box>

--- a/src/popup/components/SiteParsingSetting.tsx
+++ b/src/popup/components/SiteParsingSetting.tsx
@@ -5,8 +5,10 @@ import { Settings } from "@/background";
 
 export const SiteParsingSetting = ({
   onChange,
+  isDisabled = false,
 }: {
   onChange?: (enabled: boolean) => void;
+  isDisabled?: boolean;
 }) => {
   const [isChecked, setIsChecked] = useState(true);
 
@@ -24,7 +26,7 @@ export const SiteParsingSetting = ({
   };
 
   return (
-    <Checkbox size="sm" isChecked={isChecked} onChange={handleCheck}>
+    <Checkbox size="sm" isChecked={isChecked} isDisabled={isDisabled} onChange={handleCheck}>
       <Text fontSize="sm">
         {chrome.i18n === undefined
           ? "optionSiteParsingDesc"


### PR DESCRIPTION
## Summary
This PR adds a loading indicator while the extension is checking for image tabs, improving the user experience by providing visual feedback during the asynchronous image source detection process.

## Key Changes
- Added `isLoading` state to track when image sources are being fetched
- Wrapped `loadImages` function with try/finally to properly manage loading state
- Display a spinner with "Checking tabs..." message while loading
- Disable the Site Parsing Setting checkbox during the loading process to prevent concurrent requests
- Imported `Spinner` and `Flex` components from Chakra UI for the loading UI

## Implementation Details
- The loading state is initialized to `true` on component mount and set to `false` once image sources are loaded (or if an error occurs)
- The Site Parsing Setting checkbox is disabled during loading via the new `isDisabled` prop to prevent users from triggering multiple simultaneous image source fetches
- The loading indicator replaces the image count text while loading, then displays the results once complete

https://claude.ai/code/session_01PbWUYPbPDpnmAvaXR18Gkc