### PR TITLE
fix: add pixiv.net (without www) to host_permissions

### DIFF
--- a/manifest.config.ts
+++ b/manifest.config.ts
@@ -26,6 +26,7 @@ export default defineManifest({
     "https://yande.re/*",
     "https://files.yande.re/*",
     "https://www.pixiv.net/*",
+    "https://pixiv.net/*",
     "https://*.pximg.net/*",
   ],
   background: {


### PR DESCRIPTION
isPixivArtworkPage accepts both pixiv.net and www.pixiv.net, but host_permissions only covered www.pixiv.net. This caused executeScript to fail with a permission error when accessing artwork pages via the non-www URL.