### PR TITLE
Replace HTML anchor tags with Chakra UI Link component

### DIFF
--- a/src/popup/components/ImageTabList.tsx
+++ b/src/popup/components/ImageTabList.tsx
@@ -1,4 +1,4 @@
-import { Box, Checkbox, Flex, Spinner, Text } from "@chakra-ui/react"
+import { Box, Checkbox, Flex, Link, Spinner, Text } from "@chakra-ui/react"
 import { FiAlertTriangle } from "react-icons/fi"
 import { getSourceKey, type DownloadStatus, type ImageSource } from "@/popup/chromeApi"
 import { t } from "@/popup/i18n"
@@ -100,23 +100,21 @@ export const ImageTabList = ({
                 }}
               />
               <Box flex="1" minWidth={0} display="flex" flexDirection="column">
-                <a
+                <Link
                   href={source.imageUrl}
                   target="_blank"
                   rel="noreferrer"
                   title={source.imageUrl}
-                  style={{
-                    fontSize: "12px",
-                    color: isFailed ? "#E53E3E" : "#3182ce",
-                    overflow: "hidden",
-                    whiteSpace: "nowrap",
-                    textOverflow: "ellipsis",
-                    display: "block",
-                    minWidth: 0,
-                  }}
+                  fontSize="12px"
+                  color={isFailed ? "red.500" : "blue.500"}
+                  overflow="hidden"
+                  whiteSpace="nowrap"
+                  textOverflow="ellipsis"
+                  display="block"
+                  minWidth={0}
                 >
                   {source.imageUrl}
-                </a>
+                </Link>
                 {isFailed && (
                   <Text
                     fontSize="11px"
@@ -130,23 +128,21 @@ export const ImageTabList = ({
                   </Text>
                 )}
                 {!isFailed && source.tab.url && source.tab.url !== source.imageUrl && (
-                  <a
+                  <Link
                     href={source.tab.url}
                     target="_blank"
                     rel="noreferrer"
                     title={source.tab.url}
-                    style={{
-                      fontSize: "11px",
-                      color: "#718096",
-                      overflow: "hidden",
-                      whiteSpace: "nowrap",
-                      textOverflow: "ellipsis",
-                      display: "block",
-                      minWidth: 0,
-                    }}
+                    fontSize="11px"
+                    color="gray.500"
+                    overflow="hidden"
+                    whiteSpace="nowrap"
+                    textOverflow="ellipsis"
+                    display="block"
+                    minWidth={0}
                   >
                     Open source page
-                  </a>
+                  </Link>
                 )}
               </Box>
               {isDownloadingThis && <Spinner size="sm" color="blue.500" flexShrink={0} />}


### PR DESCRIPTION
## Summary
Refactored the `ImageTabList` component to use Chakra UI's `Link` component instead of native HTML `<a>` tags, improving consistency with the design system and enabling better styling integration.

## Key Changes
- Replaced two `<a>` elements with Chakra UI `Link` components
- Migrated inline `style` objects to Chakra UI props for better maintainability
- Updated color values to use Chakra UI's color tokens (`red.500`, `blue.500`, `gray.500`)
- Converted numeric values to proper Chakra UI format (e.g., `minWidth: 0` → `minWidth={0}`)
- Added `Link` to the Chakra UI imports

## Implementation Details
- The first link displays the image URL with conditional red/blue coloring based on download status
- The second link displays the source page URL in gray and only renders when the page URL differs from the image URL
- All styling properties (overflow, text truncation, display) are now expressed as Chakra UI props instead of inline CSS
- Maintains all original functionality including `target="_blank"`, `rel="noreferrer"`, and title attributes

https://claude.ai/code/session_01VCo34g2bPEddk4w7SfhR1w