### PR TITLE
Add OS dark mode auto-detection

### DIFF
--- a/src/popup/components/ColorModeSync.tsx
+++ b/src/popup/components/ColorModeSync.tsx
@@ -1,0 +1,15 @@
+import { useEffect } from "react"
+
+export const ColorModeSync = () => {
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-color-scheme: dark)")
+    const apply = (dark: boolean) => {
+      document.documentElement.classList.toggle("dark", dark)
+    }
+    apply(mq.matches)
+    const handler = (e: MediaQueryListEvent) => apply(e.matches)
+    mq.addEventListener("change", handler)
+    return () => mq.removeEventListener("change", handler)
+  }, [])
+  return null
+}

--- a/src/popup/main.tsx
+++ b/src/popup/main.tsx
@@ -2,10 +2,12 @@ import { StrictMode } from "react"
 import { createRoot } from "react-dom/client"
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react"
 import App from "./App.tsx"
+import { ColorModeSync } from "./components/ColorModeSync"
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <ChakraProvider value={defaultSystem}>
+      <ColorModeSync />
       <App />
     </ChakraProvider>
   </StrictMode>,


### PR DESCRIPTION
## Summary
- OSの`prefers-color-scheme`メディアクエリを監視し、ダークモード時に`<html>`要素へ`.dark`クラスを自動付与する`ColorModeSync`コンポーネントを追加
- Chakra UI v3の`_dark`セマンティックトークンが自動的に有効になり、OSの設定に連動してダークモードが適用される
- `next-themes`は Next.js 専用のため、Vite + Chrome拡張環境向けに軽量な自前実装で対応

## Test plan
- [x] 型チェック（`tsc -b`）パス
- [x] 全テスト（128件）パス
- [ ] OSのダークモード設定を切り替えて、ポップアップUIの配色が自動で変わることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqWoCHkk3k217c5h7x3CuZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqWoCHkk3k217c5h7x3CuZ)_