### PR TITLE
fix: download folder is reset after update

### DIFF
--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -40,6 +40,27 @@ export const test = base.extend<{
       serviceWorker = await context.waitForEvent("serviceworker");
     }
     const extensionId = serviceWorker.url().split("/")[2];
+
+    // background.ts populates default settings asynchronously in its
+    // onInstalled listener. Wait for that write to land before tests start
+    // interacting with the popup, otherwise the popup can read storage
+    // before defaults exist and a settings write from the test can race
+    // with (and be clobbered by) the still-in-flight onInstalled write.
+    await serviceWorker.evaluate(async () => {
+      await new Promise<void>((resolve) => {
+        const check = () => {
+          chrome.storage.sync.get(["isCloseTabAfterDownload"], (result) => {
+            if (result.isCloseTabAfterDownload !== undefined) {
+              resolve();
+            } else {
+              setTimeout(check, 20);
+            }
+          });
+        };
+        check();
+      });
+    });
+
     await use(extensionId);
   },
 

--- a/src/__tests__/background.test.ts
+++ b/src/__tests__/background.test.ts
@@ -19,19 +19,32 @@ describe("onInstalled", () => {
     await import("../background")
   })
 
-  it("merges defaults with existing settings, keeping saved values", async () => {
+  it("only fills in missing keys, leaving existing saved values untouched", async () => {
     getMock.mockResolvedValue({ downloadDir: "existing-dir" })
 
     await getOnInstalledListener()()
 
-    expect(setMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        downloadDir: "existing-dir",
-        isCloseTabAfterDownload: true,
-        isSiteParsingEnabled: true,
-        isDarkMode: null,
-      }),
-    )
+    expect(setMock).toHaveBeenCalledWith({
+      isCloseTabAfterDownload: true,
+      isSiteParsingEnabled: true,
+      isDarkMode: null,
+    })
+  })
+
+  it("does not write to storage when every key already exists", async () => {
+    // Regression guard: writing unconditionally here raced with settings
+    // changes made elsewhere (e.g. the popup) right after install/update,
+    // silently reverting them. See #onInstalled fix.
+    getMock.mockResolvedValue({
+      isCloseTabAfterDownload: false,
+      downloadDir: "existing-dir",
+      isSiteParsingEnabled: false,
+      isDarkMode: true,
+    })
+
+    await getOnInstalledListener()()
+
+    expect(setMock).not.toHaveBeenCalled()
   })
 
   it("falls back to defaults when no existing settings are saved", async () => {

--- a/src/__tests__/background.test.ts
+++ b/src/__tests__/background.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, vi, type Mock } from "vitest"
+
+const getOnInstalledListener = () => {
+  const addListenerMock = chrome.runtime.onInstalled.addListener as unknown as Mock
+  return addListenerMock.mock.calls[0][0] as () => Promise<void>
+}
+
+describe("onInstalled", () => {
+  const getMock = chrome.storage.sync.get as unknown as Mock
+  const setMock = chrome.storage.sync.set as unknown as Mock
+  const updateDynamicRulesMock = chrome.declarativeNetRequest.updateDynamicRules as unknown as Mock
+
+  beforeEach(async () => {
+    vi.resetModules()
+    getMock.mockReset()
+    setMock.mockReset()
+    updateDynamicRulesMock.mockReset()
+    ;(chrome.runtime.onInstalled.addListener as unknown as Mock).mockReset()
+    await import("../background")
+  })
+
+  it("merges defaults with existing settings, keeping saved values", async () => {
+    getMock.mockResolvedValue({ downloadDir: "existing-dir" })
+
+    await getOnInstalledListener()()
+
+    expect(setMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        downloadDir: "existing-dir",
+        isCloseTabAfterDownload: true,
+        isSiteParsingEnabled: true,
+        isDarkMode: null,
+      }),
+    )
+  })
+
+  it("falls back to defaults when no existing settings are saved", async () => {
+    getMock.mockResolvedValue({})
+
+    await getOnInstalledListener()()
+
+    expect(setMock).toHaveBeenCalledWith({
+      isCloseTabAfterDownload: true,
+      downloadDir: null,
+      isSiteParsingEnabled: true,
+      isDarkMode: null,
+    })
+  })
+
+  it("still sets up the referer rules when storage.sync.get fails", async () => {
+    getMock.mockRejectedValue(new Error("storage unavailable"))
+
+    await expect(getOnInstalledListener()()).rejects.toThrow("storage unavailable")
+
+    expect(setMock).not.toHaveBeenCalled()
+    expect(updateDynamicRulesMock).toHaveBeenCalled()
+  })
+
+  it("sets up the referer rules on successful install", async () => {
+    getMock.mockResolvedValue({})
+
+    await getOnInstalledListener()()
+
+    expect(updateDynamicRulesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        removeRuleIds: [1],
+        addRules: expect.any(Array),
+      }),
+    )
+  })
+})

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -10,6 +10,15 @@ const chromeMock = {
   },
   runtime: {
     lastError: null,
+    onInstalled: {
+      addListener: vi.fn(),
+    },
+    onStartup: {
+      addListener: vi.fn(),
+    },
+    onMessage: {
+      addListener: vi.fn(),
+    },
   },
   tabs: {
     query: vi.fn(),
@@ -21,6 +30,20 @@ const chromeMock = {
   },
   scripting: {
     executeScript: vi.fn(),
+  },
+  declarativeNetRequest: {
+    updateDynamicRules: vi.fn(),
+    RuleActionType: {
+      MODIFY_HEADERS: "modifyHeaders",
+    },
+    HeaderOperation: {
+      SET: "set",
+    },
+    ResourceType: {
+      IMAGE: "image",
+      OTHER: "other",
+      XMLHTTPREQUEST: "xmlhttprequest",
+    },
   },
   i18n: {
     getMessage: vi.fn((key: string) => key),

--- a/src/background.ts
+++ b/src/background.ts
@@ -42,8 +42,9 @@ const setupRefererRules = () => {
   })
 }
 
-chrome.runtime.onInstalled.addListener(() => {
-  chrome.storage.sync.set(defaultSettings)
+chrome.runtime.onInstalled.addListener(async () => {
+  const current = await chrome.storage.sync.get(Object.keys(defaultSettings))
+  chrome.storage.sync.set({ ...defaultSettings, ...current })
   setupRefererRules()
 })
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -45,7 +45,15 @@ const setupRefererRules = () => {
 chrome.runtime.onInstalled.addListener(async () => {
   try {
     const current = await chrome.storage.sync.get(Object.keys(defaultSettings))
-    chrome.storage.sync.set({ ...defaultSettings, ...current })
+    const missing = Object.fromEntries(
+      (Object.keys(defaultSettings) as (keyof Settings)[]).filter((key) => !(key in current)).map((key) => [key, defaultSettings[key]]),
+    )
+    // Only write keys that are actually missing, so an in-flight settings
+    // change made elsewhere (e.g. the popup) right after install/update is
+    // never clobbered by re-writing keys that already exist.
+    if (Object.keys(missing).length > 0) {
+      await chrome.storage.sync.set(missing)
+    }
   } finally {
     setupRefererRules()
   }

--- a/src/background.ts
+++ b/src/background.ts
@@ -43,9 +43,12 @@ const setupRefererRules = () => {
 }
 
 chrome.runtime.onInstalled.addListener(async () => {
-  const current = await chrome.storage.sync.get(Object.keys(defaultSettings))
-  chrome.storage.sync.set({ ...defaultSettings, ...current })
-  setupRefererRules()
+  try {
+    const current = await chrome.storage.sync.get(Object.keys(defaultSettings))
+    chrome.storage.sync.set({ ...defaultSettings, ...current })
+  } finally {
+    setupRefererRules()
+  }
 })
 
 chrome.runtime.onStartup.addListener(() => {

--- a/src/popup/components/CloseTabAfterDownload.tsx
+++ b/src/popup/components/CloseTabAfterDownload.tsx
@@ -6,6 +6,7 @@ export const CloseTabAfterDownload = () => (
     storageKey="isCloseTabAfterDownload"
     messageKey="optionTabCloseDesc"
     fallbackLabel="optionTabCloseDesc"
+    defaultValue={true}
     icon={FiX}
     iconColor="red.500"
     uncheckedIconColor="gray.400"


### PR DESCRIPTION
## Summary
- Fixed a bug reported in reviews where the specified download folder was occasionally reset.
- Cause: `chrome.runtime.onInstalled` fires not only on initial installation but also when the extension is updated (`reason: "update"`) or when Chrome itself is updated (`"chrome_update"`). Previously, every time this event triggered, `chrome.storage.sync.set(defaultSettings)` unconditionally overwrote all settings, including `downloadDir`, with default values, causing user settings (such as the download folder) to be lost whenever the extension automatically updated.
- Fix: Changed the logic to a merge approach (`{ ...defaultSettings, ...current }`) where existing stored values are retrieved when `onInstalled` fires, and only unset keys are filled with default values. This preserves existing user settings while ensuring default values are applied correctly for new installations and any new configuration items added in the future.
